### PR TITLE
Create and support DropEmpty

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,48 @@ Filters on pipelines between readers and writers.
 This library provides a method to wrap filters in the necessary input and output pipes to pull from readers and write to
 writers. It is intended to work with line-based input, and requires newline characters to call the wrapped functions.
 
+## Types
+
+* `Func` - a `func([]byte) []byte` for performing a transform of bytes with newlines.
+* `Funcs` - a `[]Func`, also capable of performing transforms of bytes with or without newlines.
+* `Filter` - an asynchronous type that takes a WriteCloser and a Reader, scans input to output on newline.
+
 ## Usage
 
-The best way to use this library is to create a reusable list of function references of the type `func([]byte) []byte`
-and wrap that in the `filter.FuncList` type, then calling its `AsChain()` function to create a new filter chain.
+The easiest way to use this library is to create a list of []Func and re-type as `filter.Funcs`. You can then
+run `Funcs.Apply([]byte) []byte` on your data.
 
 ```go
-var fl filter.FuncList = []filter.Func{bytes.TrimSpace, bytes.ToLower, bytes.Title}
+var fs filter.Funcs = []filter.Func{bytes.Trim, bytes.ToUpper}
+r := fs.Apply([]byte("hello world  "))
+// r = "HELLO WORLD"
+```
+
+For live interaction, you can bind inputs and outputs to a `Filter`. The best way do this is to create a reusable list
+of function references of the type `func([]byte) []byte` and wrap that in the `filter.Funcs` type, then calling
+its `AsChain()` function to create a new filter chain.
+
+You can create a Filter to process items concurrently.
+
+The short form:
+
+```go
+f := filter.NewFilter(os.Stdout, os.Stdin, bytes.TrimSpace, bytes.ToLower, bytes.Title)
+// if you have reason to close out (done doing the process, found what you wanted to, etc.)
+// normally you'd put this behind a timeout or other condition.
+_ = f.Close()
+
+// perform interactions, ctrl-d or ctrl-c to interrupt.
+_ = f.Wait()
+```
+
+The reusable form:
+```go
+var fs filter.Funcs = []filter.Func{bytes.TrimSpace, bytes.ToLower, bytes.Title}
 
 // We're using Stdout and Stdin, because it's convenient for demonstration.
-// If you're going to pipe in data, use os.Pipe instead of io.Pipe
-f, _ := fl.AsChain(os.Stdout, os.Stdin)
+// If you're going to pipe in data, use os.Pipe instead of io.Pipe.
+f, _ := fs.AsFilter(os.Stdout, os.Stdin)
 
 // if you have reason to close out (done doing the process, found what you wanted to, etc.)
 // normally you'd put this behind a timeout or other condition.

--- a/filter.go
+++ b/filter.go
@@ -171,6 +171,8 @@ func (fs Funcs) applyRow(s []byte) []byte {
 	return work
 }
 
+// DropEmpty returns nil on an empty slice. This allows us
+// to eliminate rows that have no meaning in output elsewhere.
 func DropEmpty(s []byte) []byte {
 	if len(s) == 0 {
 		return nil

--- a/filter_test.go
+++ b/filter_test.go
@@ -31,7 +31,7 @@ func TestFilter(tt *testing.T) {
 			expectedOutput: []byte{},
 		},
 		{
-			name:  "apply DropEmpty nothing",
+			name:  "apply DropEmpty",
 			input: []byte("hello\n\nworld\n"),
 			createFunc: func(t *wrapt.T, w io.Writer, r io.ReadCloser) *filter.Filter {
 				f := createDefaultFilter(t, w, r)


### PR DESCRIPTION
- Add DropEmpty filter that returns nil on an empty row
- All filter paths will drop a row if a Func returns nil
- Remove err from Apply because it uses bytes.Buffer, which never errs.